### PR TITLE
Edit jog route

### DIFF
--- a/src/components/Lap.js
+++ b/src/components/Lap.js
@@ -24,13 +24,13 @@ function Lap(props) {
   return (
     <div
       ref={drag}
-      className={`lap lap--${props.lap.name}`}
+      className={`lap lap--${lap.name}`}
       data-testid={`lap-${lap.name}`}
     >
       <h3>{lap.name}</h3>
       <p>
         <span className="label">Total length</span>
-        {formatDistanceInKms(props.lap.getLapLength())}km
+        {formatDistanceInKms(lap.getLapLength())}km
       </p>
     </div>
   );

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -46,6 +46,18 @@ function Main(props) {
             <Redirect from="/create" to="/" />
           )}
         </Route>
+        <Route path="/edit/:jogRouteId">
+          {loading ? (
+            <h3>Loading...</h3>
+          ) : user ? (
+            <DndProvider backend={HTML5Backend}>
+              <Laps />
+              <RoutePlanner user={user} firestore={props.firestore} />
+            </DndProvider>
+          ) : (
+            <Redirect from="/edit/:jogRouteId" to="/" />
+          )}
+        </Route>
         <Route path="/jog-route/:jogRouteId">
           <Single firestore={props.firestore} />
         </Route>

--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -27,6 +27,9 @@ function Profile(props) {
         className="jog-route"
         style={{ animationDelay: index !== 0 ? `${index * 0.1}s` : null }}
       >
+        {jogRoute?.updatedAt && (
+          <p>Updated@{formatFirebaseTimestamp(jogRoute.updatedAt)}</p>
+        )}
         <p>Created@{formatFirebaseTimestamp(jogRoute.createdAt)}</p>
         <p>Laps: {jogRoute.laps.length}</p>
         <p>Length: {jogRoute.length}km</p>
@@ -66,7 +69,7 @@ function Profile(props) {
             <>
               <h3>Your jog routes</h3>
               {jogRoutes
-                .sort(sortByTimestampDesc('createdAt'))
+                .sort(sortByTimestampDesc('updatedAt'))
                 .map(renderJogRoute)}
             </>
           )}

--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -6,6 +6,7 @@ import { useCollectionDataOnce } from 'react-firebase-hooks/firestore';
 import Loader from './Loader';
 
 import { formatFirebaseTimestamp, sortByTimestampDesc } from '../helpers';
+import { LOCAL_STORAGE_KEYS } from '../constants';
 
 import '../scss/components/_profile.scss';
 
@@ -35,13 +36,22 @@ function Profile(props) {
         <p>Length: {jogRoute.length}km</p>
         <div className="jog-route__actions">
           <Link
-            to={{
-              pathname: '/create',
-              state: {
-                jogRoute,
-              },
-            }}
+            to={`/edit/${jogRoute.id}`}
             className="edit"
+            onClick={function persistJogRouteInLocalStorage() {
+              localStorage.setItem(
+                LOCAL_STORAGE_KEYS.CURRENTLY_EDITING_JOG_ROUTE,
+                JSON.stringify(jogRoute)
+              );
+            }}
+            onAuxClick={function persistJogRouteIfOpenedInNewTab(event) {
+              if (event.button === 1 || event.ctrlKey || event.shiftKey) {
+                localStorage.setItem(
+                  LOCAL_STORAGE_KEYS.CURRENTLY_EDITING_JOG_ROUTE,
+                  JSON.stringify(jogRoute)
+                );
+              }
+            }}
           >
             Edit
           </Link>

--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -22,16 +22,31 @@ function Profile(props) {
 
   function renderJogRoute(jogRoute, index) {
     return (
-      <Link
-        to={`/jog-route/${jogRoute.id}`}
+      <div
         key={index}
-        className="jog-routes__item"
+        className="jog-route"
         style={{ animationDelay: index !== 0 ? `${index * 0.1}s` : null }}
       >
         <p>Created@{formatFirebaseTimestamp(jogRoute.createdAt)}</p>
         <p>Laps: {jogRoute.laps.length}</p>
         <p>Length: {jogRoute.length}km</p>
-      </Link>
+        <div className="jog-route__actions">
+          <Link
+            to={{
+              pathname: '/create',
+              state: {
+                jogRoute,
+              },
+            }}
+            className="edit"
+          >
+            Edit
+          </Link>
+          <Link to={`/jog-route/${jogRoute.id}`} className="details">
+            Details
+          </Link>
+        </div>
+      </div>
     );
   }
 
@@ -44,7 +59,7 @@ function Profile(props) {
       {loading ? (
         <Loader />
       ) : (
-        <div className="jog-routes">
+        <div className="container">
           {jogRoutes.length === 0 ? (
             <h3>You don't have any jog routes. Go and create some 🏃‍♂️!</h3>
           ) : (

--- a/src/components/RoutePlanner.js
+++ b/src/components/RoutePlanner.js
@@ -19,6 +19,7 @@ function RoutePlanner(props) {
     .doc(props.user.uid);
 
   const location = useLocation();
+  const isEditExistingRoute = !!location.state;
 
   useEffect(() => {
     if (location.state) {
@@ -158,13 +159,47 @@ function RoutePlanner(props) {
     clearJogRoute();
   }
 
+  function updateJogRoute() {
+    var jogRouteRef = props.firestore
+      .collection('jogRoutes')
+      .doc(location.state.jogRoute.id);
+
+    var laps = jogRoute.map(function keepOnlyName(lap) {
+      return lap.name;
+    });
+    var jogRouteLength = getJogRouteLength();
+
+    jogRouteRef.update({
+      updatedAt: firebase.firestore.FieldValue.serverTimestamp(),
+      laps,
+      length: jogRouteLength,
+    });
+  }
+
+  function renderActions() {
+    if (jogRoute.length > 1) {
+      return (
+        <div className="route-planner__actions">
+          <button
+            className="button button--large"
+            onClick={isEditExistingRoute ? updateJogRoute : saveJogRoute}
+          >
+            {isEditExistingRoute ? 'Update' : 'Save'} jog route
+          </button>
+          <button className="button button--large" onClick={clearJogRoute}>
+            Clear
+          </button>
+        </div>
+      );
+    }
+
+    return null;
+  }
+
   return (
     <div className="route-planner" data-testid="route-planner">
-      <h2>Route planner</h2>
-      {jogRoute.length > 1 && (
-        <button onClick={saveJogRoute}>Save route</button>
-      )}
-      <button onClick={clearJogRoute}>Clear jog route</button>
+      <h2>Route Planner - {isEditExistingRoute ? 'edit' : 'create'}</h2>
+      {renderActions()}
       <div
         ref={drop}
         className={getDropzoneClassNames()}

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,6 +2,13 @@ export const DragItemTypes = {
   LAP: 'lap',
 };
 
+var LOCAL_STORAGE_KEYS = Object.create(null);
+Object.assign(LOCAL_STORAGE_KEYS, {
+  CURRENTLY_EDITING_JOG_ROUTE: 'currentlyEditingJogRoute',
+});
+
+export { LOCAL_STORAGE_KEYS };
+
 let lap = {
   getLapLength() {
     return this.sides.reduce((acc, curr) => acc + curr, 0);

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,29 +3,29 @@ export const DragItemTypes = {
 };
 
 let lap = {
-  getLapLength: function () {
+  getLapLength() {
     return this.sides.reduce((acc, curr) => acc + curr, 0);
   },
 };
 
 export let laps = {
-  small: Object.assign(Object.create(lap), {
+  s: Object.assign(Object.create(lap), {
     name: 's',
     sides: [170, 49, 180, 54],
   }),
-  medium: Object.assign(Object.create(lap), {
+  m: Object.assign(Object.create(lap), {
     name: 'm',
     sides: [350, 74, 350, 59],
   }),
-  large: Object.assign(Object.create(lap), {
+  l: Object.assign(Object.create(lap), {
     name: 'l',
     sides: [520, 74, 530, 54],
   }),
-  xlarge: Object.assign(Object.create(lap), {
+  xl: Object.assign(Object.create(lap), {
     name: 'xl',
     sides: [600, 50, 650, 85],
   }),
-  xxlarge: Object.assign(Object.create(lap), {
+  xxl: Object.assign(Object.create(lap), {
     name: 'xxl',
     sides: [1100, 74, 1100, 82],
   }),

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -28,6 +28,18 @@ export function formatFirebaseTimestamp(timestamp) {
 
 export function sortByTimestampDesc(timestampKey) {
   return function (doc1, doc2) {
+    if (doc1[timestampKey] === undefined && doc2[timestampKey] === undefined) {
+      return 0;
+    }
+
+    if (doc1[timestampKey] === undefined && doc2[timestampKey] !== undefined) {
+      return 1;
+    }
+
+    if (doc1[timestampKey] !== undefined && doc2[timestampKey] === undefined) {
+      return -1;
+    }
+
     return doc1[timestampKey].toDate() > doc2[timestampKey].toDate() ? -1 : 1;
   };
 }

--- a/src/scss/components/_profile.scss
+++ b/src/scss/components/_profile.scss
@@ -22,7 +22,7 @@
     }
   }
 
-  .jog-routes {
+  .container {
     display: flex;
     flex-wrap: wrap;
     grid-gap: 20px;
@@ -31,15 +31,47 @@
       width: 100%;
     }
 
-    .jog-routes__item {
+    .jog-route {
       text-decoration: none;
       color: inherit;
+      box-shadow: 0 0.5em 1em -0.125em rgba(10, 10, 10, 0.1),
+        0 0 0 1px rgba(10, 10, 10, 0.02);
 
       @include jog-route;
       @include fade-in;
 
       &:hover {
         border-color: palette.$secondary;
+      }
+
+      .jog-route__actions {
+        display: flex;
+        justify-content: space-around;
+        align-items: center;
+
+        > * {
+          padding: 0.5em 0.75em;
+          border: 1px solid transparent;
+          border-radius: 4px;
+          display: inline-block;
+          color: inherit;
+          text-decoration: none;
+          letter-spacing: 0.02em;
+          font-weight: 600;
+          transition: border-color 0.125s ease-in-out;
+
+          &:hover {
+            border-color: palette.$darker;
+          }
+        }
+
+        .edit {
+          background-color: palette.$warning--lighter;
+        }
+
+        .details {
+          background-color: palette.$success--lighter;
+        }
       }
     }
   }

--- a/src/scss/components/_profile.scss
+++ b/src/scss/components/_profile.scss
@@ -45,6 +45,7 @@
       }
 
       .jog-route__actions {
+        margin-top: auto;
         display: flex;
         justify-content: space-around;
         align-items: center;

--- a/src/scss/components/_route-planner.scss
+++ b/src/scss/components/_route-planner.scss
@@ -97,3 +97,13 @@
     }
   }
 }
+
+.route-planner__actions {
+  display: flex;
+  grid-gap: 1.5em;
+  justify-content: stretch;
+
+  > * {
+    flex: 1;
+  }
+}

--- a/src/scss/mixins/_jog-route.scss
+++ b/src/scss/mixins/_jog-route.scss
@@ -3,6 +3,9 @@
 @mixin jog-route {
   padding: 1.5rem;
   border: 1px solid palette.$dark;
+  display: flex;
+  flex-direction: column;
+  grid-gap: 0.75em;
   background-color: white;
 
   > *:not(:last-child) {


### PR DESCRIPTION
Closes #29 
- [x] `<RoutePlanner />` renders with pre-filled jog route data if accesed through edit link from profile  
- [x] `<RoutePlanner />` renders buttons for save/update based on navigation
- [x] editing a route in a new tab resets history/doesn't forward the `state` present on the edit `<Link />`



